### PR TITLE
Add simple web UI for agent

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,2 @@
+import config from './.eslintrc.cjs';
+export default config;

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,11 +1,14 @@
-const { createDefaultPreset } = require("ts-jest");
+import { createDefaultPreset } from 'ts-jest';
 
 const tsJestTransformCfg = createDefaultPreset().transform;
 
-/** @type {import("jest").Config} **/
+/** @type {import('jest').Config} */
 export default {
-  testEnvironment: "node",
+  testEnvironment: 'node',
   transform: {
     ...tsJestTransformCfg,
+  },
+  moduleNameMapper: {
+    '^(\\.{1,2}/.*)\\.js$': '$1',
   },
 };

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "dev:proxy": "nodemon --watch src --exec ts-node src/proxy/server.ts",
     "dev:client": "ts-node src/client/mcpClientTester.ts",
     "dev:agent": "nodemon --watch src --exec ts-node src/agent/run.ts",
+    "dev:ui": "nodemon --watch src --watch public --exec ts-node src/ui/run.ts",
     "build": "tsc -p tsconfig.json",
     "test": "jest --runInBand",
     "lint": "eslint ."

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Dev Assistant UI</title>
+  <style>
+    body { font-family: sans-serif; margin: 2rem; }
+    #result { white-space: pre-wrap; background: #f0f0f0; padding: 1rem; margin-top: 1rem; }
+  </style>
+</head>
+<body>
+  <h1>Dev Assistant</h1>
+  <input id="query" type="text" size="50" placeholder="Enter your query" />
+  <button id="send">Send</button>
+  <pre id="result"></pre>
+  <script>
+    document.getElementById('send').addEventListener('click', async () => {
+      const query = document.getElementById('query').value;
+      const res = await fetch('/query', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ query })
+      });
+      const data = await res.json();
+      document.getElementById('result').textContent = JSON.stringify(data, null, 2);
+    });
+  </script>
+</body>
+</html>

--- a/src/ui/run.ts
+++ b/src/ui/run.ts
@@ -1,0 +1,5 @@
+import { createServer } from './server.js';
+
+const port = Number(process.env.UI_PORT || 3000);
+const app = createServer();
+app.listen(port, () => console.log(`Dev Assistant UI at http://localhost:${port}`));

--- a/src/ui/server.ts
+++ b/src/ui/server.ts
@@ -1,0 +1,26 @@
+import express from 'express';
+import path from 'path';
+import { handleQuery } from '../agent/agent.js';
+
+export function createServer(queryHandler: (q: string) => Promise<any> = handleQuery) {
+  const app = express();
+  app.use(express.json());
+
+  const publicDir = path.join(process.cwd(), 'public');
+  app.use(express.static(publicDir));
+
+  app.post('/query', async (req, res) => {
+    const { query } = req.body || {};
+    if (typeof query !== 'string' || !query.trim()) {
+      return res.status(400).json({ error: 'query required' });
+    }
+    try {
+      const result = await queryHandler(query);
+      return res.json(result);
+    } catch (err: any) {
+      return res.status(500).json({ error: err?.message || 'handler error' });
+    }
+  });
+
+  return app;
+}

--- a/tests/ui.test.ts
+++ b/tests/ui.test.ts
@@ -1,0 +1,17 @@
+import request from 'supertest';
+import { createServer } from '../src/ui/server';
+
+test('POST /query requires query', async () => {
+  const app = createServer(async () => ({}));
+  const res = await request(app).post('/query').send({});
+  expect(res.status).toBe(400);
+});
+
+test('POST /query returns handler result', async () => {
+  const mock = jest.fn().mockResolvedValue({ ok: true });
+  const app = createServer(mock);
+  const res = await request(app).post('/query').send({ query: 'hello' });
+  expect(res.status).toBe(200);
+  expect(res.body).toEqual({ ok: true });
+  expect(mock).toHaveBeenCalledWith('hello');
+});


### PR DESCRIPTION
## Summary
- add lightweight Express UI server with static HTML client
- expose `/query` endpoint for agent queries and bundle run script
- test UI endpoint and modernize Jest config

## Testing
- `pnpm test`
- `pnpm lint` *(fails: config object is using the "parser" key, which is not supported in flat config system)*

------
https://chatgpt.com/codex/tasks/task_e_68b031ad62988323bc6b5fda68c1beb9