### PR TITLE
feat: add deterministic embeddings fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,13 @@ This project provides a simple MCP proxy, a dev assistant agent with RAG, and a 
 
 The UI serves `public/index.html` on `http://localhost:3000/` and exposes an API at `/api/query`.
 
+## Environment Variables
+
+- `GOOGLE_API_KEY` – used for building real embeddings. If unset, tests fall back to deterministic `FakeEmbeddings`.
+- `GITHUB_PERSONAL_ACCESS_TOKEN` – required for the GitHub MCP server.
+- `PORT` – port for the proxy server (defaults to `8002`).
+- `UI_PORT` – port for the web UI (defaults to `3000`).
+
 ## Testing
 
 Run all tests with:

--- a/src/rag/setup.ts
+++ b/src/rag/setup.ts
@@ -1,6 +1,7 @@
 import { RecursiveCharacterTextSplitter } from 'langchain/text_splitter';
 import { MemoryVectorStore } from 'langchain/vectorstores/memory';
 import { GoogleGenerativeAIEmbeddings } from '@langchain/google-genai';
+import { FakeEmbeddings } from 'langchain/embeddings/fake';
 import fs from 'fs';
 import path from 'path';
 import { config } from 'dotenv';
@@ -27,12 +28,12 @@ export async function buildRetriever(kbDir = 'mock_knowledge_base') {
     const splits = await splitter.splitText(text);
     docs.push(...splits.map((t, i) => ({ pageContent: t, metadata: { file, i } })));
   }
-  console.log(process.env.GOOGLE_API_KEY);
-
-  const embeddings = new GoogleGenerativeAIEmbeddings({
-    apiKey: process.env.GOOGLE_API_KEY,
-    model: "models/embedding-001", // uses GOOGLE_API_KEY
-  });
+  const embeddings = process.env.GOOGLE_API_KEY
+    ? new GoogleGenerativeAIEmbeddings({
+        apiKey: process.env.GOOGLE_API_KEY,
+        model: "models/embedding-001", // uses GOOGLE_API_KEY
+      })
+    : new FakeEmbeddings();
   const store = await MemoryVectorStore.fromDocuments(docs as any, embeddings);
   return store.asRetriever(5);
 }


### PR DESCRIPTION
## Summary
- remove GOOGLE_API_KEY logging and fall back to FakeEmbeddings when the key is absent
- document environment variables required by the server

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5409bb4d48323b513d93e4544c8bd