### PR TITLE
feat: expand client tester for dynamic calls

### DIFF
--- a/docs/mcp_server_exploration.md
+++ b/docs/mcp_server_exploration.md
@@ -1,0 +1,64 @@
+# MCP Server Exploration
+
+This document demonstrates using `mcpClientTester.ts` to interact with the mock MCP servers through the proxy.
+
+## Filesystem Mock Server
+
+### `get_methods`
+
+```bash
+npx ts-node src/client/mcpClientTester.ts filesystem get_methods
+```
+
+Sample response:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "1",
+  "result": [
+    { "name": "list_files", "params": { "path": "string" }, "description": "List files in a directory" },
+    { "name": "read_file",  "params": { "path": "string" }, "description": "Read a file" }
+  ]
+}
+```
+
+### `invoke_method` – `list_files`
+
+```bash
+npx ts-node src/client/mcpClientTester.ts filesystem invoke_method '{"name":"list_files","arguments":{"path":"mock_knowledge_base"}}'
+```
+
+Sample response:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "1",
+  "result": [
+    "code",
+    "docs",
+    "jira_tickets.json",
+    "tickets"
+  ]
+}
+```
+
+### `invoke_method` – `read_file`
+
+```bash
+npx ts-node src/client/mcpClientTester.ts filesystem invoke_method '{"name":"read_file","arguments":{"path":"mock_knowledge_base/jira_tickets.json"}}'
+```
+
+Sample response (truncated):
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "1",
+  "result": "[\n    {\n      \"ticket_id\": \"NEX-123\", ..."
+}
+```
+
+These examples show how different MCP calls can be issued through the proxy using the target key, method name, and JSON parameters.
+

--- a/src/client/mcpClientTester.ts
+++ b/src/client/mcpClientTester.ts
@@ -11,9 +11,19 @@
 import axios from 'axios';
 
 async function main() {
-  const [,, proxyUrl = 'http://localhost:8002/mcp/filesystem', method = 'get_methods'] = process.argv;
-  const payload = { jsonrpc: '2.0', method, id: '1', params: {} };
-  const { data } = await axios.post(proxyUrl, payload);
+  const [,, target = 'filesystem', method = 'get_methods', params = '{}', proxyBase = 'http://localhost:8002'] = process.argv;
+
+  let parsedParams: any = {};
+  try {
+    parsedParams = JSON.parse(params);
+  } catch (err) {
+    console.error('Failed to parse params JSON:', err);
+    process.exit(1);
+  }
+
+  const payload = { jsonrpc: '2.0', method, id: '1', params: parsedParams };
+  const url = `${proxyBase}/mcp/${target}`;
+  const { data } = await axios.post(url, payload);
   console.log(JSON.stringify(data, null, 2));
 }
 


### PR DESCRIPTION
## Summary
- expand `mcpClientTester.ts` to take target, method, and JSON params and post to `${proxyBase}/mcp/${target}`
- document example interactions with the filesystem mock server

## Testing
- `pnpm test`
- `pnpm lint` *(fails: ESLint couldn't find an eslint.config file)*

------
https://chatgpt.com/codex/tasks/task_e_68b53da094f48323afc8a5f3be6fc8e0