### PR TITLE
Add UI error handling test and end-to-end flow

### DIFF
--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -1,0 +1,54 @@
+import request from 'supertest';
+import express from 'express';
+import axios from 'axios';
+import http from 'http';
+import { createApp } from '../src/ui/server';
+
+jest.mock('../src/rag/setup', () => ({
+  buildRetriever: jest.fn().mockResolvedValue({
+    getRelevantDocuments: jest.fn().mockResolvedValue([
+      { pageContent: 'hello world', metadata: { file: 'mock.txt' } }
+    ])
+  })
+}));
+
+describe('end-to-end query flow', () => {
+  let fsServer: http.Server;
+  let proxyServer: http.Server;
+
+  beforeAll(async () => {
+    const fsApp = express();
+    fsApp.use(express.json());
+    fsApp.post('/', (req, res) => {
+      res.json({ jsonrpc: '2.0', id: req.body.id, result: { methods: ['get_methods'] } });
+    });
+    await new Promise<void>(resolve => {
+      fsServer = fsApp.listen(7001, () => resolve());
+    });
+
+    const proxyApp = express();
+    proxyApp.use(express.json());
+    proxyApp.post('/mcp/:target', async (req, res) => {
+      if (req.params.target !== 'filesystem') return res.status(404).json({ error: 'Unknown target' });
+      const { data } = await axios.post('http://localhost:7001', req.body);
+      res.json(data);
+    });
+    await new Promise<void>(resolve => {
+      proxyServer = proxyApp.listen(8002, () => resolve());
+    });
+  });
+
+  afterAll(() => {
+    fsServer.close();
+    proxyServer.close();
+  });
+
+  test('query succeeds through full stack', async () => {
+    const app = createApp();
+    const res = await request(app).post('/api/query').send({ query: 'filesystem question' });
+    expect(res.status).toBe(200);
+    expect(res.body.targetUsed).toBe('filesystem');
+    expect(res.body.mcpSnippet).toBeDefined();
+    expect(res.body.ragContextPreview[0].text).toContain('hello world');
+  });
+});

--- a/tests/ui.test.ts
+++ b/tests/ui.test.ts
@@ -21,4 +21,12 @@ describe('UI query endpoint', () => {
     const res = await request(app).post('/api/query').send({});
     expect(res.status).toBe(400);
   });
+
+  test('handles agent errors with 500', async () => {
+    handleQuery.mockRejectedValueOnce(new Error('boom'));
+    const app = createApp();
+    const res = await request(app).post('/api/query').send({ query: 'test' });
+    expect(res.status).toBe(500);
+    expect(res.body).toEqual({ error: 'boom' });
+  });
 });


### PR DESCRIPTION
## Summary
- test UI server returns 500 when agent fails
- add integration test covering filesystem through proxy and agent

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5409da36c83239ede43a1b95cae01