### PR TITLE
feat: improve agent query parsing and coverage

### DIFF
--- a/src/agent/agent.ts
+++ b/src/agent/agent.ts
@@ -3,19 +3,37 @@ import { buildRetriever } from '../rag/setup';
 
 type ToolTarget = 'github' | 'filesystem' | 'atlassian' | 'gdrive';
 
-export async function handleQuery(query: string, proxyBase = 'http://localhost:8002') {
-  // naive parse: look for "github|filesystem|atlassian|gdrive"
-  const target = (['github','filesystem','atlassian','gdrive'].find(t => query.toLowerCase().includes(t)) ?? 'filesystem') as ToolTarget;
+// lazily build and reuse the RAG retriever
+let retrieverPromise: ReturnType<typeof buildRetriever> | null = null;
+async function getRetriever() {
+  if (!retrieverPromise) retrieverPromise = buildRetriever();
+  return retrieverPromise;
+}
 
-  // Example: translate to an MCP call
-  const mcpPayload = { jsonrpc: '2.0', method: 'get_methods', id: 'demo' };
-  const { data: mcpResult } = await axios.post(`${proxyBase}/mcp/${target}`, mcpPayload);
-  const retriever = await buildRetriever();
+export function parseQuery(query: string): { tool: ToolTarget; action: string; args: Record<string, string> } {
+  const parts = query.trim().split(/\s+/);
+  const tool = (['github', 'filesystem', 'atlassian', 'gdrive'].includes(parts[0]) ? parts[0] : 'filesystem') as ToolTarget;
+  const action = parts[1] ?? 'get_methods';
+  const argsParts = parts.slice(2);
+  const args: Record<string, string> = {};
+  for (const p of argsParts) {
+    const [k, v] = p.split('=');
+    if (k) args[k] = v ?? '';
+  }
+  return { tool, action, args };
+}
+
+export async function handleQuery(query: string, proxyBase = 'http://localhost:8002') {
+  const { tool, action, args } = parseQuery(query);
+
+  const mcpPayload = { jsonrpc: '2.0', method: 'invoke_method', params: { method: action, ...args }, id: 'demo' };
+  const { data: mcpResult } = await axios.post(`${proxyBase}/mcp/${tool}`, mcpPayload);
+
+  const retriever = await getRetriever();
   const ragDocs = await retriever.getRelevantDocuments(query);
-  console.log(ragDocs)
-  // super simple synthesis
+
   return {
-    targetUsed: target,
+    parsed: { tool, action, args },
     mcpSnippet: mcpResult?.result ?? mcpResult,
     ragContextPreview: ragDocs.slice(0, 2).map(d => ({ file: d.metadata?.file, text: d.pageContent.slice(0, 30000) }))
   };

--- a/tests/agent.test.ts
+++ b/tests/agent.test.ts
@@ -1,0 +1,53 @@
+
+describe('agent query handling', () => {
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  test('parses query, invokes MCP and synthesizes', async () => {
+    const mockRetriever = {
+      getRelevantDocuments: jest.fn().mockResolvedValue([
+        { metadata: { file: 'a.txt' }, pageContent: 'hello world' }
+      ])
+    };
+
+    jest.doMock('axios', () => ({ post: jest.fn().mockResolvedValue({ data: { result: 'ok' } }) }));
+    jest.doMock('../src/rag/setup', () => ({ buildRetriever: jest.fn().mockResolvedValue(mockRetriever) }));
+
+    const { handleQuery } = require('../src/agent/agent');
+    const axios = require('axios');
+    const { buildRetriever } = require('../src/rag/setup');
+
+    const res = await handleQuery('github get_user user=octocat');
+
+    expect(res.parsed).toEqual({ tool: 'github', action: 'get_user', args: { user: 'octocat' } });
+    expect((axios.post as jest.Mock)).toHaveBeenCalledWith('http://localhost:8002/mcp/github', {
+      jsonrpc: '2.0',
+      method: 'invoke_method',
+      params: { method: 'get_user', user: 'octocat' },
+      id: 'demo'
+    });
+    expect(mockRetriever.getRelevantDocuments).toHaveBeenCalledWith('github get_user user=octocat');
+    expect(res.mcpSnippet).toBe('ok');
+    expect(res.ragContextPreview).toEqual([{ file: 'a.txt', text: 'hello world' }]);
+    expect((buildRetriever as jest.Mock)).toHaveBeenCalledTimes(1);
+  });
+
+  test('reuses retriever between calls', async () => {
+    const mockRetriever = {
+      getRelevantDocuments: jest.fn().mockResolvedValue([])
+    };
+
+    jest.doMock('axios', () => ({ post: jest.fn().mockResolvedValue({ data: { result: 'ok' } }) }));
+    jest.doMock('../src/rag/setup', () => ({ buildRetriever: jest.fn().mockResolvedValue(mockRetriever) }));
+
+    const { handleQuery } = require('../src/agent/agent');
+    const { buildRetriever } = require('../src/rag/setup');
+
+    await handleQuery('filesystem read path=/a');
+    await handleQuery('filesystem read path=/b');
+
+    expect((buildRetriever as jest.Mock)).toHaveBeenCalledTimes(1);
+    expect(mockRetriever.getRelevantDocuments).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## Summary
- parse `{tool, action, args}` from user queries and reuse a single retriever instance
- map parsed actions to `invoke_method` payloads for MCP proxy
- test agent query handling with mocked axios and retriever

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find a config file)*

------
https://chatgpt.com/codex/tasks/task_e_68b54098695c8323948b3fde80ae223b