### PR TITLE
Add proxy integration tests

### DIFF
--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -4,7 +4,7 @@ import { z } from 'zod';
 import { TARGETS, type TargetKey } from '../config/targets';
 import 'dotenv/config';
 
-const app = express();
+export const app = express();
 app.use(express.json({ limit: '2mb' }));
 
 const JsonRpcSchema = z.object({
@@ -37,7 +37,7 @@ app.get('/mcp/get_methods', async (_req, res) => {
   const entries = Object.entries(TARGETS) as [TargetKey, string][];
   const results = await Promise.allSettled(entries.map(async ([key, url]) => {
     const payload = { jsonrpc: '2.0', method: 'get_methods', id: `gm-${key}` };
-    console.log(payload, entries)
+    console.log(payload, entries);
     const { data } = await axios.post(url, payload, { timeout: 10000 });
     return [key, data] as const;
   }));
@@ -45,5 +45,7 @@ app.get('/mcp/get_methods', async (_req, res) => {
   res.json({ aggregated });
 });
 
-const port = Number(process.env.PORT || 8002);
-app.listen(port, () => console.log(`MCP Proxy listening on http://localhost:${port}`));
+if (require.main === module) {
+  const port = Number(process.env.PORT || 8002);
+  app.listen(port, () => console.log(`MCP Proxy listening on http://localhost:${port}`));
+}

--- a/tests/proxy.test.ts
+++ b/tests/proxy.test.ts
@@ -1,16 +1,82 @@
-import request from 'supertest';
 import http from 'http';
-import express from 'express';
+import request from 'supertest';
+import nock from 'nock';
 
-test('proxy rejects unknown target', async () => {
-  const app = express();
-  app.use(express.json());
-  app.post('/mcp/:target', (req, res) => res.status(404).json({ error: 'Unknown target foo' }));
-  const server = http.createServer(app);
-  await new Promise(r => server.listen(0, () => r(undefined)));
-  const addr = server.address() as any;
-  const base = `http://127.0.0.1:${addr.port}`;
-  const res = await request(base).post('/mcp/foo').send({ jsonrpc: '2.0', method: 'get_methods' });
-  expect(res.status).toBe(404);
+let server: http.Server;
+
+beforeAll(async () => {
+  process.env.MCP_FILESYSTEM_URL = 'http://localhost:7101';
+  process.env.MCP_GITHUB_URL = 'http://localhost:7102';
+  process.env.MCP_ATLASSIAN_URL = 'http://localhost:7103';
+  process.env.MCP_GDRIVE_URL = 'http://localhost:7104';
+  process.env.MCP_PLAYWRIGHT_URL = 'http://localhost:7105';
+
+  const mod = await import('../src/proxy/server');
+  server = http.createServer(mod.app);
+  await new Promise<void>(resolve => server.listen(0, resolve));
+});
+
+afterAll(() => {
   server.close();
 });
+
+afterEach(() => {
+  nock.cleanAll();
+});
+
+test('proxy rejects unknown target', async () => {
+  const res = await request(server)
+    .post('/mcp/unknown')
+    .send({ jsonrpc: '2.0', method: 'ping' });
+  expect(res.status).toBe(404);
+  expect(res.body.error).toMatch(/Unknown target/);
+});
+
+test('forwards payload and returns downstream response', async () => {
+  nock('http://localhost:7101')
+    .post('/', { jsonrpc: '2.0', method: 'ping', id: 1 })
+    .reply(200, { jsonrpc: '2.0', result: 'pong', id: 1 });
+
+  const res = await request(server)
+    .post('/mcp/filesystem')
+    .send({ jsonrpc: '2.0', method: 'ping', id: 1 });
+
+  expect(res.status).toBe(200);
+  expect(res.body).toEqual({ jsonrpc: '2.0', result: 'pong', id: 1 });
+});
+
+test('propagates downstream error responses', async () => {
+  nock('http://localhost:7101')
+    .post('/').reply(500, { error: 'downstream failure' });
+
+  const res = await request(server)
+    .post('/mcp/filesystem')
+    .send({ jsonrpc: '2.0', method: 'ping' });
+
+  expect(res.status).toBe(500);
+  expect(res.body.error).toBeDefined();
+});
+
+test('aggregates get_methods across configured targets', async () => {
+  const targets = [
+    ['filesystem', 'http://localhost:7101', 'fs methods'],
+    ['github', 'http://localhost:7102', 'gh methods'],
+    ['atlassian', 'http://localhost:7103', 'atl methods'],
+    ['gdrive', 'http://localhost:7104', 'gd methods'],
+    ['playwright', 'http://localhost:7105', 'pw methods']
+  ] as const;
+
+  for (const [key, url, result] of targets) {
+    nock(url)
+      .post('/', { jsonrpc: '2.0', method: 'get_methods', id: `gm-${key}` })
+      .reply(200, { jsonrpc: '2.0', id: `gm-${key}`, result });
+  }
+
+  const res = await request(server).get('/mcp/get_methods');
+
+  expect(res.status).toBe(200);
+  expect(res.body.aggregated).toEqual(
+    targets.map(([key, _url, result]) => [key, { jsonrpc: '2.0', id: `gm-${key}`, result }])
+  );
+});
+


### PR DESCRIPTION
## Summary
- expose Express app and guard server startup so tests can run the proxy without opening a port
- add integration tests for proxy payload forwarding, error propagation, and get_methods aggregation using nock

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b54096624c8323a5dd92f1ce6c52d3